### PR TITLE
keep original key on row

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ function List (db, tag, fn) {
 List.prototype.seed = function () {
   var self = this;
   self.stream = live(self.db, function (change) {
-    var id = Array.prototype.join.call(change.key, "");
+    var key = change.key;
+    var id = Array.prototype.join.call(key, "");
     var row;
 
     // delete?
@@ -62,7 +63,7 @@ List.prototype.seed = function () {
     // create row
     row = new Emitter();
     merge(row, change.value);
-    row._key = id;
+    row._key = key;
     row._element = self._create(row);
     self.rows[id] = row;
 


### PR DESCRIPTION
Keeping the original key on the row will prevent a possible recreation of the row on change.
